### PR TITLE
ci: created release workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,43 @@
+# This workflow will build and upload a runner jar to keep around for 7 days
+
+name: ci-build
+
+on:
+  push:
+    branches:
+      - main
+    tags-ignore:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        server-id: github
+        settings-path: ${{ github.workspace }}
+        cache: maven
+
+    - name: Build
+      run: mvn -B package -Dquarkus.package.jar.type=uber-jar --file pom.xml
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: leyden-analyzer-runner
+        path: target/*-runner.jar
+        retention-days: 7

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,0 +1,34 @@
+# This workflow will build and create a release when a tag starting with "v" is pushed
+
+name: ci-release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        server-id: github
+        settings-path: ${{ github.workspace }}
+        cache: maven
+
+    - name: Build
+      run: mvn -B package -Dquarkus.package.jar.type=uber-jar -DskipTests --file pom.xml
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: target/*-runner.jar

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,10 +1,7 @@
 {
   "aliases": {
     "analyzer": {
-      "script-ref": "com.github.quintesse:leyden-analyzer:jitpack-SNAPSHOT:runner",
-      "repositories": [
-        "jitpack"
-      ],
+      "script-ref": "https://github.com/quintesse/leyden-analyzer/releases/latest/download/leyden-analyzer-1.0.0-SNAPSHOT-runner.jar",
       "java": "21"
     }
   }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,0 @@
-before_install:
-  - sdk install java 21-tem
-  - sdk use java 21-tem
-install:
-  - ./mvnw clean install -DskipTests -Dquarkus.package.jar.type=uber-jar


### PR DESCRIPTION
I created a workflow that will build and test on each push. It will then store the resulting -runner.jar in the workflow run for 7 days. You can manually download the JAR at any time and run it with `java -jar`.

But there's also a release workflow that will trigger whenever you create (and push) a tag with a name that starts with a "v", eg "v1" or "v3.7.0". It will then also build a -runner.jar but it will be published permanently as a release on GitHub.

And this released JAR (always the one marked "latest") is what JBang will use if you run `jbang analyzer@leyden-analyzer/Delawen`. This way which version is run by JBang is under your control. It's also much faster and more stable than using JitPack.