### PR TITLE
feat: Add argument on startup to load files from command line

### DIFF
--- a/src/main/java/tooling/leyden/QuarkusPicocliLineApp.java
+++ b/src/main/java/tooling/leyden/QuarkusPicocliLineApp.java
@@ -44,6 +44,13 @@ public class QuarkusPicocliLineApp implements Runnable, QuarkusApplication {
     @Inject
     CommandLine.IFactory factory;
 
+    @CommandLine.Option(arity = "1..*", paramLabel = "<file>", description = "files to load", names = {"productionLog"})
+    private Path[] productionLog;
+    @CommandLine.Option(arity = "1..*", paramLabel = "<file>", description = "files to load", names = {"trainingLog"})
+    private Path[] trainingLog;
+    @CommandLine.Option(arity = "1..*", paramLabel = "<file>", description = "files to load", names = {"aotCache"})
+    private Path[] aotCache;
+
     private static Status status;
     private static Information information;
 
@@ -137,6 +144,21 @@ public class QuarkusPicocliLineApp implements Runnable, QuarkusApplication {
 
                 // start the shell and process input until the user quits with Ctrl-D
                 String line;
+                if (productionLog != null) {
+                    for (Path p : productionLog) {
+                        systemRegistry.execute("load --background productionLog " + p.toString());
+                    }
+                }
+                if (trainingLog != null) {
+                    for (Path p : trainingLog) {
+                        systemRegistry.execute("load --background productionLog " + p.toString());
+                    }
+                }
+                if (aotCache != null) {
+                    for (Path p : aotCache) {
+                        systemRegistry.execute("load --background aotCache " + p.toString());
+                    }
+                }
                 while (true) {
                     try {
                         systemRegistry.cleanUp();


### PR DESCRIPTION
Now we can add our files to load from the `java -jar` command:

`java -jar target/quarkus-app/quarkus-run.jar aotCache=..../aot.map  productionLog=..../production.log productionLog=..../app.out trainingLog=..../training.log* `

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
There is no valid unit test (yet) for this. We need to add some testing library to test from command line instead of Java first.

## Checklist:

- [x] This is not AI slop
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

