### PR TITLE
feat: adding support for https://github.com/openjdk/jdk/pull/30778

### DIFF
--- a/.github/workflows/ci-pr-native.yml
+++ b/.github/workflows/ci-pr-native.yml
@@ -73,8 +73,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         mandrel:
-          - java: '21'
-            version: '23.1.10.0-Final'
           - java: '25'
             version: '25.0.2.0-Final'
         java: # If you change it here, change it above too

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
@@ -136,6 +136,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
                 <configuration>
+                    <source>${maven.compiler.release}</source>
+                    <target>${maven.compiler.release}</target>
                     <parameters>true</parameters>
                 </configuration>
             </plugin>

--- a/src/main/java/tooling/leyden/aotcache/CodeObject.java
+++ b/src/main/java/tooling/leyden/aotcache/CodeObject.java
@@ -1,0 +1,42 @@
+package tooling.leyden.aotcache;
+
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+
+/**
+ * This class represents an element on the Code Cache
+ */
+public class CodeObject extends ReferencingElement {
+
+    private Integer id = null;
+
+    CodeObject(String identifier, String type) {
+        super(identifier, type);
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getKey() {
+        return "[" + this.getId() + "] " + super.getKey();
+    }
+
+    @Override
+    public AttributedString getDescription(String leftPadding, Boolean verbose, Boolean tips) {
+        AttributedStringBuilder sb = new AttributedStringBuilder();
+        sb.append(super.getDescription(leftPadding, verbose, tips));
+        if (verbose) {
+            sb.append(AttributedString.NEWLINE);
+            sb.append(leftPadding).append("This is part of the Code Cache.");
+        }
+        return sb.toAttributedString();
+    }
+
+}

--- a/src/main/java/tooling/leyden/aotcache/ElementFactory.java
+++ b/src/main/java/tooling/leyden/aotcache/ElementFactory.java
@@ -19,6 +19,8 @@ public class ElementFactory {
             case "KlassTrainingData", "CompileTrainingData", "MethodData", "MethodCounters", "MethodTrainingData",
                     "Symbol" -> e = new ReferencingElement(identifier, type);
             case "Object" -> e = new InstanceObject(identifier);
+            case "Nmethod" -> e = new NMethodObject(identifier);
+            case "StubGenBlob", "SharedBlob", "C1Blob", "C2Blob", "Adapter" -> e = new CodeObject(identifier, type);
             default -> {
                 e = new BasicObject(identifier);
                 e.setType(type);

--- a/src/main/java/tooling/leyden/aotcache/NMethodObject.java
+++ b/src/main/java/tooling/leyden/aotcache/NMethodObject.java
@@ -1,0 +1,135 @@
+package tooling.leyden.aotcache;
+
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.AttributedStyle;
+import tooling.leyden.commands.logparser.AOTMapParser;
+
+import java.util.*;
+
+/**
+ * This class represents a native compiled method inside the AOT Cache.
+ */
+public class NMethodObject extends CodeObject {
+
+    private MethodObject method;
+    private Integer compilationLevel;
+
+    public NMethodObject(String identifier) {
+        super(identifier, "NMethod");
+    }
+
+    public MethodObject getMethod() {
+        return method;
+    }
+
+    public void setMethod(String identifier) {
+        // translate method signature
+
+        // primitives like  [I convert to int[]
+        // int[] java.math.BigInteger.subtract(int[], int[])
+        // java.math.BigInteger.subtract([I[I)[I
+
+        String[] parameters = identifier.substring(identifier.indexOf("(") + 1, identifier.lastIndexOf(")")).split(";");
+        for (int i = 0; i < parameters.length; i++) {
+            parameters[i] = translateSymbols(parameters[i]);
+        }
+        String returnType = translateSymbols(identifier.substring(identifier.lastIndexOf(")") + 1));
+
+        String signature = identifier.substring(0, identifier.indexOf("("));
+
+        // move return type to the front
+        // java.math.BigInteger.subtract(Ljava/math/BigInteger;)Ljava/math/BigInteger;
+        // java.math.BigInteger java.math.BigInteger.subtract(java.math.BigInteger)
+        String methodIdentifier = returnType + " " + signature + "(" + String.join(", ", parameters) + ")";
+        this.method = (MethodObject) ElementFactory.getOrCreate(methodIdentifier, "Method", null);
+        this.addReference(this.getMethod());
+    }
+
+    private String translateSymbols(String symbol) {
+        //Take care of arrays
+        List<String> symbols = new ArrayList<>(Arrays.asList(symbol.split("\\[")));
+        if (symbols.size() > 1) {
+            symbols.removeFirst();
+            symbols = symbols.stream().map(s ->translateSymbol(s) + "[]").toList();
+        } else {
+            symbols = symbols.stream().map(s ->translateSymbol(s)).toList();
+        }
+
+        return String.join(", ", symbols);
+    }
+
+    private String translateSymbol(String symbol) {
+        symbol = symbol.replaceAll("/", ".");
+
+        if (symbol.startsWith("L") && symbol.endsWith(";")) {
+            symbol = symbol.substring(1, symbol.length() - 1);
+        } else if (symbol.startsWith("L")) {
+            symbol = symbol.substring(1, symbol.length());
+        }
+
+        switch (symbol) {
+            case "B" -> symbol = "byte";
+            case "S" -> symbol = "short";
+            case "I" -> symbol = "int";
+            case "J" -> symbol = "long";
+            case "F" -> symbol = "float";
+            case "D" -> symbol = "double";
+            case "Z" -> symbol = "boolean";
+            case "C" -> symbol = "char";
+            case "V" -> symbol = "void";
+            default -> { }
+        }
+
+        return symbol;
+    }
+
+    public Integer getCompilationLevel() {
+        return compilationLevel;
+    }
+
+    public void setCompilationLevel(Integer compilationLevel) {
+        this.compilationLevel = compilationLevel;
+    }
+
+    @Override
+    public String getKey() {
+        return "(" + this.getCompilationLevel() + ") " + super.getKey();
+    }
+
+    @Override
+    public boolean isTrained() {
+        return true;
+    }
+
+    @Override
+    public boolean isTraineable() {
+        return true;
+    }
+
+    @Override
+    public AttributedString getDescription(String leftPadding, Boolean verbose, Boolean tips) {
+        AttributedStringBuilder sb = new AttributedStringBuilder();
+        sb.append(super.getDescription(leftPadding, verbose, tips));
+        if (verbose) {
+            sb.append(AttributedString.NEWLINE);
+            sb.append(leftPadding).append("This is the compiled code of the method").append(method.getKey()).append(".");
+        }
+        sb.append(AttributedString.NEWLINE);
+        sb.append(leftPadding).append("Compilation Level: " + this.getCompilationLevel());
+        if (verbose) {
+            sb.append(AttributedString.NEWLINE);
+            sb.style(AttributedStyle.DEFAULT.foreground(AttributedStyle.BRIGHT));
+            sb.append(leftPadding).append("  ℹ\uFE0F  Higher compilation levels mean a more optimized compilation.");
+        }
+        if (tips) {
+            sb.append(AttributedString.NEWLINE);
+            sb.style(AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW));
+            sb.append(leftPadding).append("  \uD83D\uDCA1  Key methods should aim for compilation 3 or above.");
+        }
+        sb.style(AttributedStyle.DEFAULT);
+
+        return sb.toAttributedString();
+    }
+
+}

--- a/src/main/java/tooling/leyden/commands/InfoCommand.java
+++ b/src/main/java/tooling/leyden/commands/InfoCommand.java
@@ -14,6 +14,7 @@ import picocli.CommandLine.Command;
 import tooling.leyden.aotcache.Configuration;
 import tooling.leyden.aotcache.Element;
 import tooling.leyden.aotcache.MethodObject;
+import tooling.leyden.aotcache.NMethodObject;
 import tooling.leyden.commands.autocomplete.InfoCommandTypes;
 import tooling.leyden.commands.autocomplete.WhichRun;
 
@@ -141,6 +142,7 @@ class InfoCommand extends BaseCommand {
         params.setTypes(new String[] { "Method" });
         params.setUse(CommonParameters.ElementsToUse.cached);
         var futureMethodsSize = parent.getInformation().getFutureElements(params);
+        var futureMethods = parent.getInformation().getFutureElements(params);
         params = new CommonParameters();
         params.setUse(CommonParameters.ElementsToUse.cached);
         params.setTypes(new String[] { "KlassTrainingData" });
@@ -158,7 +160,34 @@ class InfoCommand extends BaseCommand {
         params.setTypes(new String[] { "MethodTrainingData" });
         var futureMethodTrainingData = parent.getInformation().getFutureElements(params);
 
-        var lambdas = Double.valueOf(stats.getValue("[LOG] Lambda Methods loaded from AOT Cache", 0).toString());
+        //code cache
+        params = new CommonParameters();
+        params.setUse(CommonParameters.ElementsToUse.cached);
+        params.setTypes(new String[] { "NMethod" });
+        var futureNMethod = parent.getInformation().getFutureElements(params);
+        var futureNMethodCount = parent.getInformation().getFutureElements(params);
+        params = new CommonParameters();
+        params.setUse(CommonParameters.ElementsToUse.cached);
+        params.setTypes(new String[] { "StubGenBlob" });
+        var futureStubGenBlob = parent.getInformation().getFutureElements(params);
+        params = new CommonParameters();
+        params.setUse(CommonParameters.ElementsToUse.cached);
+        params.setTypes(new String[] { "SharedBlob" });
+        var futureSharedBlob = parent.getInformation().getFutureElements(params);
+        params = new CommonParameters();
+        params.setUse(CommonParameters.ElementsToUse.cached);
+        params.setTypes(new String[] { "Adapter" });
+        var futureAdapter = parent.getInformation().getFutureElements(params);
+        params = new CommonParameters();
+        params.setUse(CommonParameters.ElementsToUse.cached);
+        params.setTypes(new String[] { "C1Blob" });
+        var futureC1Blob = parent.getInformation().getFutureElements(params);
+        params = new CommonParameters();
+        params.setUse(CommonParameters.ElementsToUse.cached);
+        params.setTypes(new String[] { "C2Blob" });
+        var futureC2Blob = parent.getInformation().getFutureElements(params);
+
+    var lambdas = Double.valueOf(stats.getValue("[LOG] Lambda Methods loaded from AOT Cache", 0).toString());
         final double methodsSize = getFutureDouble(futureMethodsSize);
 
         (new AttributedString("PRODUCTION RUN: ", blueFormat)).println(parent.getTerminal());
@@ -198,27 +227,6 @@ class InfoCommand extends BaseCommand {
             printPercentage("  -> Not Cached:", lambdas + extLambdas, percentFormat, redFormat, extLambdas);
             printVerboseInfo("Lambda methods used in production but not cached. Sometimes there are issues storing " +
                     "specific classes and methods. Check for warnings with the warning command.");
-
-            Integer aotCodeEntries = Integer
-                    .valueOf(stats.getValue("[LOG] [CodeCache] Loaded AOT code entries", -1).toString());
-            printVerboseInfo("Summarized information of what has been used from the Code Cache.");
-            if (aotCodeEntries > 0) {
-                (new AttributedString(
-                        "Code Entries: " + aotCodeEntries, AttributedStyle.DEFAULT)).println(parent.getTerminal());
-                printVerboseInfo("Total number of entries loaded from the Code Cache.");
-                printPercentage("  -> Adapters: ", aotCodeEntries.doubleValue(), percentFormat, greenFormat,
-                        Double.valueOf(stats.getValue("[LOG] [CodeCache] Loaded Adapters", 0).toString()));
-                printPercentage("  -> Shared Blobs: ", aotCodeEntries.doubleValue(), percentFormat,
-                        greenFormat,
-                        Double.valueOf(stats.getValue("[LOG] [CodeCache] Loaded Shared Blobs", 0).toString()));
-                printPercentage("  -> C1 Blobs: ", aotCodeEntries.doubleValue(), percentFormat,
-                        greenFormat, Double.valueOf(stats.getValue("[LOG] [CodeCache] Loaded C1 Blobs", 0).toString()));
-                printPercentage("  -> C2 Blobs: ", aotCodeEntries.doubleValue(), percentFormat,
-                        greenFormat, Double.valueOf(stats.getValue("[LOG] [CodeCache] Loaded C2 Blobs", 0).toString()));
-                (new AttributedString(
-                        "AOT code cache size: " + stats.getValue("[LOG] [CodeCache] AOT code cache size", 0),
-                        AttributedStyle.DEFAULT)).println(parent.getTerminal());
-            }
         }
 
         (new AttributedString("AOT CACHE: ", blueFormat)).println(parent.getTerminal());
@@ -286,70 +294,63 @@ class InfoCommand extends BaseCommand {
             printVerboseInfo("MethodData and MethodTrainingData shows how many of those methods were profiled " +
                     "and to what extent.");
 
-            Map<Integer, Integer> compilationLevels = new HashMap<>();
-            parent.getInformation().getElements(null, null, null, true, false, "Method")
-                    .forEach(e -> {
-                        MethodObject method = (MethodObject) e;
-                        for (Map.Entry<Integer, Element> entry : method.getCompileTrainingData().entrySet()) {
-                            compilationLevels.putIfAbsent(entry.getKey(), 0);
-                            compilationLevels.replace(entry.getKey(), compilationLevels.get(entry.getKey()) + 1);
-                        }
-                    });
+            Map<Integer, Integer> trainingCompilationLevels = new HashMap<>();
+            try {
+                futureMethods.get().forEach(e -> {
+                    MethodObject method = (MethodObject) e;
+                    for (Map.Entry<Integer, Element> entry : method.getCompileTrainingData().entrySet()) {
+                        trainingCompilationLevels.putIfAbsent(entry.getKey(), 0);
+                        trainingCompilationLevels.replace(entry.getKey(), trainingCompilationLevels.get(entry.getKey()) + 1);
+                    }
+                });
+            } catch (Exception e) {
+            }
 
             (new AttributedString("  -> CompileTrainingData: ",
                     AttributedStyle.DEFAULT)).println(parent.getTerminal());
             printVerboseInfo("Information to compile methods to different levels/tiers of compilation.");
-            for (Integer level : compilationLevels.keySet().stream().sorted().toList()) {
+            for (Integer level : trainingCompilationLevels.keySet().stream().sorted().toList()) {
                 printPercentage("      -> Level " + level + ": ", methodsSize, percentFormat,
-                        greenFormat, Double.valueOf(compilationLevels.get(level)));
+                        greenFormat, Double.valueOf(trainingCompilationLevels.get(level)));
             }
             printVerboseInfo("The same method could store information to compile on more than one level. " +
                     "Percentages reflect the percentage of methods compiled to this level.");
             printVerboseTip("You can find compilation levels of any method with the command " +
                     "'describe -t=Method -i=\"void com.example.Class.method(com.example.Argument, com.example.Argument2)\"'.");
 
-        }
 
-        var aotCodeEntries = (Double) stats.getValue("[CodeCache] AOT Code Entries", -1.0);
-        if (aotCodeEntries > 0) {
-
-            (new AttributedString("Code Cache: ", AttributedStyle.DEFAULT)).println(parent.getTerminal());
-
-            printPercentage("  -> None: ", aotCodeEntries,
-                    percentFormat, greenFormat, (Double) stats.getValue("[CodeCache] None", 0.0));
-            printPercentage("  -> Adapter: ", aotCodeEntries,
-                    percentFormat, greenFormat, (Double) stats.getValue("[CodeCache] Adapter", 0.0));
-            printPercentage("  -> Stub: ", aotCodeEntries,
-                    percentFormat, greenFormat, (Double) stats.getValue("[CodeCache] Stub", 0.0));
-            printPercentage("  -> SharedBlob: ", aotCodeEntries,
-                    percentFormat, greenFormat, (Double) stats.getValue("[CodeCache] SharedBlob", 0.0));
-            printPercentage("  -> C1Blob: ", aotCodeEntries,
-                    percentFormat, greenFormat, (Double) stats.getValue("[CodeCache] C1Blob", 0.0));
-            printPercentage("  -> C2Blob: ", aotCodeEntries,
-                    percentFormat, greenFormat, (Double) stats.getValue("[CodeCache] C2Blob", 0.0));
-            var nmethod = (Double) stats.getValue("[CodeCache] Nmethod", 0.0);
-            printPercentage("  -> Nmethod: ", aotCodeEntries, percentFormat, greenFormat, nmethod);
-            if (nmethod > 0) {
-                printPercentage("     - Tier 0: ", nmethod,
-                        percentFormat, greenFormat, (Double) stats.getValue("[CodeCache] Nmethod Tier 0", 0.0));
-                printPercentage("     - Tier 1: ", nmethod,
-                        percentFormat, greenFormat, (Double) stats.getValue("[CodeCache] Nmethod Tier 1", 0.0));
-                printPercentage("     - Tier 2: ", nmethod,
-                        percentFormat, greenFormat, (Double) stats.getValue("[CodeCache] Nmethod Tier 2", 0.0));
-                printPercentage("     - Tier 3: ", nmethod,
-                        percentFormat, greenFormat, (Double) stats.getValue("[CodeCache] Nmethod Tier 3", 0.0));
-                printPercentage("     - Tier 4: ", nmethod,
-                        percentFormat, greenFormat, (Double) stats.getValue("[CodeCache] Nmethod Tier 4", 0.0));
-                printPercentage("     - Tier 5: ", nmethod,
-                        percentFormat, greenFormat, (Double) stats.getValue("[CodeCache] Nmethod Tier 5", 0.0));
+            Double nmethods = getFutureDouble(futureNMethodCount);
+            printVerboseInfo("Summarized information of what is inside the Code Cache.");
+            printVerboseTip("This section is only available on newer versions of the JDK.");
+            if (nmethods > 0) {
+                Map<Integer, Integer> compilationLevels = new HashMap<>();
+                try {
+                    futureNMethod.get().forEach(e -> {
+                        int compilationLevel = ((NMethodObject) e).getCompilationLevel();
+                        compilationLevels.putIfAbsent(compilationLevel, 0);
+                        compilationLevels.replace(compilationLevel, compilationLevels.get(compilationLevel) + 1);
+                    });
+                } catch (Exception e) {
+                }
+                (new AttributedString("Code Cache:", AttributedStyle.DEFAULT)).println(parent.getTerminal());
+                (new AttributedString(" - NMethods: ", AttributedStyle.DEFAULT)).print(parent.getTerminal());
+                (new AttributedString("" + nmethods.intValue(), greenFormat)).println(parent.getTerminal());
+                printVerboseInfo("Code compiled stored on the cache");
+                for (Integer level : compilationLevels.keySet().stream().sorted().toList()) {
+                    printPercentage("      -> Tier " + level + ": ", nmethods, percentFormat,
+                            greenFormat, Double.valueOf(compilationLevels.get(level)));
+                }
+                (new AttributedString(" - Adapters: ", AttributedStyle.DEFAULT)).print(parent.getTerminal());
+                (new AttributedString("" + getFutureLong(futureAdapter), greenFormat)).println(parent.getTerminal());
+                (new AttributedString(" - StubGenBlob: ", AttributedStyle.DEFAULT)).print(parent.getTerminal());
+                (new AttributedString("" + getFutureLong(futureStubGenBlob), greenFormat)).println(parent.getTerminal());
+                (new AttributedString(" - SharedBlob: ", AttributedStyle.DEFAULT)).print(parent.getTerminal());
+                (new AttributedString("" + getFutureLong(futureSharedBlob), greenFormat)).println(parent.getTerminal());
+                (new AttributedString(" - C1Blob: ", AttributedStyle.DEFAULT)).print(parent.getTerminal());
+                (new AttributedString("" + getFutureLong(futureC1Blob), greenFormat)).println(parent.getTerminal());
+                (new AttributedString(" - C2Blob: ", AttributedStyle.DEFAULT)).print(parent.getTerminal());
+                (new AttributedString("" + getFutureLong(futureC2Blob), greenFormat)).println(parent.getTerminal());
             }
-            (new AttributedString("  -> Entries: ", AttributedStyle.DEFAULT)).print(parent.getTerminal());
-            (new AttributedString(intFormat.format(aotCodeEntries), greenFormat)).println(parent.getTerminal());
-
-            (new AttributedString("  -> Cache Size: ", AttributedStyle.DEFAULT)).print(parent.getTerminal());
-            (new AttributedString(
-                    stats.getValue("[CodeCache] Cache Size", "unknown").toString(), greenFormat))
-                    .println(parent.getTerminal());
         }
     }
 
@@ -357,6 +358,15 @@ class InfoCommand extends BaseCommand {
         double count;
         try {
             count = (double) future.get().count();
+        } catch (Exception e) {
+            count = -1;
+        }
+        return count;
+    }
+    private static long getFutureLong(Future<Stream<Element>> future) {
+        long count;
+        try {
+            count = future.get().count();
         } catch (Exception e) {
             count = -1;
         }

--- a/src/main/java/tooling/leyden/commands/logparser/AOTMapParser.java
+++ b/src/main/java/tooling/leyden/commands/logparser/AOTMapParser.java
@@ -25,6 +25,10 @@ public class AOTMapParser extends Parser {
     // 0x00000000ffe94558: @@ Object (0xffe94558) java.lang.String "sun.util.locale.BaseLocale"
     // 0x00000000ffef4720: @@ Object (0xffef4720) java.lang.Class Lsun/util/locale/BaseLocale$1;
     // 0x0000000801cd0518: @@ MethodTrainingData 96
+    // 0x00007fbcf7ffbdf0: @@ C2Blob            333 71 vthread_end_transition_blob (C2 runtime)
+    // 0x00007fbcf7ffbd98: @@ Adapter           1342 220 LIIIL
+    // 0x00007fbcf7fe5500: @@ Nmethod           2788 2 2906 java.util.concurrent.ConcurrentHashMap$MapEntry.<init>(Ljava/lang/Object;Ljava/lang/Object;Ljava/util/concurrent/ConcurrentHashMap;)V
+
     private final Pattern assetHeader = Pattern.compile(regexpAddress + ": @@ (?<type>\\w+)(?: data)?\\s+"
             + "(?<miniaddress>\\(0[xX][0-9a-fA-F]+\\))?"
             + "(?<size>\\d+)?\\s*(?<identifier>.*)");
@@ -351,7 +355,49 @@ public class AOTMapParser extends Parser {
             } else if (type.equalsIgnoreCase("CArray")) {
                 //0x0000000800439bb8: @@ CArray            24
                 element = ElementFactory.getOrCreate(address, type, address);
-            } else {
+            }  else if (type.equalsIgnoreCase("Nmethod")) {
+                //0x00007fbcf7fe5500: @@ Nmethod           2788 2 2906 java.util.concurrent.ConcurrentHashMap$MapEntry.<init>(Ljava/lang/Object;Ljava/lang/Object;Ljava/util/concurrent/ConcurrentHashMap;)V
+                //0x00007fbcf7fe54d4: @@ Nmethod           5552 2 2905 java.util.concurrent.ConcurrentHashMap$EntryIterator.next()Ljava/util/Map$Entry;
+                //0x00007fbcf7fe25e8: @@ Nmethod           11537 4 3183 java.math.BigInteger.subtract([I[I)[I
+                //0x00007fbcf7fe25bc: @@ Nmethod           6965 4 3251 java.util.regex.Pattern$CharProperty.match(Ljava/util/regex/Matcher;ILjava/lang/CharSequence;)Z
+                int index = identifier.indexOf(" ");
+                int compilationLevel = Integer.valueOf(identifier.substring(0, index));
+                identifier = identifier.substring(index + 1);
+                index = identifier.indexOf(" ");
+                int id = Integer.valueOf(identifier.substring(0, index));
+                identifier = identifier.substring(index + 1);
+                element = ElementFactory.getOrCreate(identifier, type, address);
+                ((NMethodObject)element).setCompilationLevel(compilationLevel);
+                ((NMethodObject)element).setId(id);
+                ((NMethodObject)element).setMethod(identifier);
+            } else if (type.equalsIgnoreCase( "StubGenBlob")
+                    || type.equalsIgnoreCase( "SharedBlob")
+                    || type.equalsIgnoreCase( "StubGenBlob")
+                    || type.equalsIgnoreCase( "C1Blo")
+                    || type.equalsIgnoreCase( "StubGenBlob")
+                    || type.equalsIgnoreCase( "C2Blob")
+                    || type.equalsIgnoreCase( "Adapter")) {
+                //0x00007fbcf7ffeff4: @@ StubGenBlob       25896 73 initial_blob (stub gen)
+                //0x00007fbcf7ffefc8: @@ SharedBlob        403 13 throw_StackOverflowError_blob (shared runtime)
+                //0x00007fbcf7ffef9c: @@ StubGenBlob       3621 74 continuation_blob (stub gen)
+                //0x00007fbcf7ffed34: @@ SharedBlob        2156 0 deopt_blob (shared runtime)
+                //0x00007fbcf7ffe49c: @@ StubGenBlob       129373 75 compiler_blob (stub gen)
+                //0x00007fbcf7ffe470: @@ StubGenBlob       59182 76 final_blob (stub gen)
+                //0x00007fbcf7ffcc8c: @@ C1Blob            650 17 dtrace_object_alloc_blob (C1 runtime)
+                //0x00007fbcf7ffcc60: @@ C1Blob            387 18 unwind_exception_blob (C1 runtime)
+                //0x00007fbcf7ffbe74: @@ C2Blob            335 70 vthread_start_transition_blob (C2 runtime)
+                //0x00007fbcf7ffbe48: @@ Adapter           1333 217 ILIL
+                //0x00007fbcf7ffbe1c: @@ Adapter           1376 218 LIIILLL
+                //0x00007fbcf7ffbdf0: @@ C2Blob            333 71 vthread_end_transition_blob (C2 runtime)
+                //0x00007fbcf7ffbdc4: @@ Adapter           1460 219 LLLIILILLII
+                //0x00007fbcf7ffbd98: @@ Adapter           1342 220 LIIIL
+                int index = identifier.indexOf(" ");
+                int id = Integer.valueOf(identifier.substring(0, index));
+                identifier = identifier.substring(index + 1);
+                element = ElementFactory.getOrCreate(identifier, type, address);
+                ((CodeObject)element).setId(id);
+            }
+            else {
                 loadFile.getParent().getOut().println("Unidentified: " + type + " at address " + address);
                 element = ElementFactory.getOrCreate(address, type, address);
             }
@@ -461,7 +507,7 @@ public class AOTMapParser extends Parser {
         return element;
     }
 
-    private static String convertSymbolSignatureToClassQualifiedName(String identifier) {
+    public static String convertSymbolSignatureToClassQualifiedName(String identifier) {
         //Lorg/aspectj/weaver/ast/ASTNode;  -> org.aspectj.weaver.ast.ASTNode
         //[Lcom/fasterxml/jackson/databind/JsonSerializable; -> [Lcom.fasterxml.jackson.databind.JsonSerializable;
         identifier = identifier.replaceAll("/", ".");

--- a/src/main/java/tooling/leyden/commands/logparser/AOTMapParser.java
+++ b/src/main/java/tooling/leyden/commands/logparser/AOTMapParser.java
@@ -372,9 +372,7 @@ public class AOTMapParser extends Parser {
                 ((NMethodObject)element).setMethod(identifier);
             } else if (type.equalsIgnoreCase( "StubGenBlob")
                     || type.equalsIgnoreCase( "SharedBlob")
-                    || type.equalsIgnoreCase( "StubGenBlob")
-                    || type.equalsIgnoreCase( "C1Blo")
-                    || type.equalsIgnoreCase( "StubGenBlob")
+                    || type.equalsIgnoreCase( "C1Blob")
                     || type.equalsIgnoreCase( "C2Blob")
                     || type.equalsIgnoreCase( "Adapter")) {
                 //0x00007fbcf7ffeff4: @@ StubGenBlob       25896 73 initial_blob (stub gen)

--- a/src/test/java/tooling/leyden/commands/logparser/AOTCacheParserTest.java
+++ b/src/test/java/tooling/leyden/commands/logparser/AOTCacheParserTest.java
@@ -1,11 +1,5 @@
 package tooling.leyden.commands.logparser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.StringReader;
@@ -21,6 +15,8 @@ import tooling.leyden.aotcache.*;
 import tooling.leyden.commands.CommonParameters;
 import tooling.leyden.commands.DefaultTest;
 import tooling.leyden.commands.LoadFileCommand;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
 class AOTCacheParserTest extends DefaultTest {
@@ -744,4 +740,100 @@ class AOTCacheParserTest extends DefaultTest {
         assertEquals("java.base", e.getKey());
     }
 
+
+    @Test
+    void codeCache() {
+        String mapfile = """
+0x00000008003eb000: @@ Class             1000 java.math.BigInteger
+0x00000008003ed000: @@ Class             520 [Ljava.math.BigInteger;
+0x00000008003ed400: @@ Class             520 [[Ljava.math.BigInteger;
+0x00007fbcf7ffeff4: @@ StubGenBlob       25896 73 initial_blob (stub gen)
+0x00007fbcf7ffefc8: @@ SharedBlob        403 13 throw_StackOverflowError_blob (shared runtime)
+0x00007fbcf7ffef9c: @@ StubGenBlob       3621 74 continuation_blob (stub gen)
+0x00007fbcf7ffed34: @@ SharedBlob        2156 0 deopt_blob (shared runtime)
+0x00007fbcf7ffe49c: @@ StubGenBlob       129373 75 compiler_blob (stub gen)
+0x00007fbcf7ffe470: @@ StubGenBlob       59182 76 final_blob (stub gen)
+0x00007fbcf7ffcc8c: @@ C1Blob            650 17 dtrace_object_alloc_blob (C1 runtime)
+0x00007fbcf7ffcc60: @@ C1Blob            387 18 unwind_exception_blob (C1 runtime)
+0x00007fbcf7ffbe74: @@ C2Blob            335 70 vthread_start_transition_blob (C2 runtime)
+0x00007fbcf7ffbe48: @@ Adapter           1333 217 ILIL
+0x00007fbcf7ffbe1c: @@ Adapter           1376 218 LIIILLL
+0x00007fbcf7ffbdf0: @@ C2Blob            333 71 vthread_end_transition_blob (C2 runtime)
+0x00007fbcf7ffbdc4: @@ Adapter           1460 219 LLLIILILLII
+0x00007fbcf7ffbd98: @@ Adapter           1342 220 LIIIL
+0x00000008003ec258: @@ Method            112 java.math.BigInteger java.math.BigInteger.subtract(java.math.BigInteger)
+0x00000008003eebd0: @@ Method            112 int[] java.math.BigInteger.subtract(long, int[])
+0x00000008003eecd8: @@ Method            112 int[] java.math.BigInteger.subtract(int[], int[])
+0x00000008012d6d58: @@ ConstMethod       256 java.math.BigInteger java.math.BigInteger.subtract(java.math.BigInteger)
+0x00000008012db2f8: @@ ConstMethod       344 int[] java.math.BigInteger.subtract(long, int[])
+0x00000008012db5b8: @@ ConstMethod       296 int[] java.math.BigInteger.subtract(int[], int[])
+0x00007fe0fbff6b70: @@ Nmethod           15469 4 1298 java.math.BigInteger.subtract([I[I)[I
+0x00007fe0fbfe8890: @@ Nmethod           6552 2 2131 java.math.BigInteger.subtract(Ljava/math/BigInteger;)Ljava/math/BigInteger;
+0x00007fe0fbfe28d4: @@ Nmethod           11533 4 3154 java.math.BigInteger.subtract([I[I)[I
+0x00007f9ab3fe6c60: @@ Nmethod           2444 2 2550 java.util.Arrays.sort([Ljava/lang/Object;Ljava/util/Comparator;)V
+                """;
+
+        BufferedReader reader = new BufferedReader(new StringReader(mapfile));
+        reader.lines().forEach(aotCacheParser::accept);
+        aotCacheParser.postProcessing();
+
+        CommonParameters param = new CommonParameters();
+        param.setTypes(new String[] { "NMethod" });
+        assertEquals(4, information.getElements(param).count());
+        param.setTypes(new String[] { "StubGenBlob" });
+        assertEquals(4, information.getElements(param).count());
+        param.setTypes(new String[] { "SharedBlob" });
+        assertEquals(2, information.getElements(param).count());
+        param.setTypes(new String[] { "C1Blob" });
+        assertEquals(2, information.getElements(param).count());
+        param.setTypes(new String[] { "C2Blob" });
+        assertEquals(2, information.getElements(param).count());
+        param.setTypes(new String[] { "Adapter" });
+        assertEquals(4, information.getElements(param).count());
+
+        NMethodObject e = (NMethodObject) information.getByAddress("0x00007fe0fbff6b70");
+        assertEquals("NMethod", e.getType());
+        assertFalse(e.isHeapRoot());
+        assertEquals(15469, e.getSize());
+        assertEquals(4, e.getCompilationLevel());
+        assertEquals(1298, e.getId());
+        assertNotNull(e.getMethod());
+        assertEquals("(" + e.getCompilationLevel() + ") [" + e.getId()
+                + "] java.math.BigInteger.subtract([I[I)[I", e.getKey());
+        assertEquals("0x00000008003eecd8", e.getMethod().getAddress());
+
+        e = (NMethodObject) information.getByAddress("0x00007fe0fbfe8890");
+        assertEquals("NMethod", e.getType());
+        assertFalse(e.isHeapRoot());
+        assertEquals(6552, e.getSize());
+        assertEquals(2, e.getCompilationLevel());
+        assertEquals(2131, e.getId());
+        assertNotNull(e.getMethod());
+        assertEquals("(" + e.getCompilationLevel() + ") [" + e.getId()
+                + "] java.math.BigInteger.subtract(Ljava/math/BigInteger;)Ljava/math/BigInteger;", e.getKey());
+        assertEquals("0x00000008003ec258", e.getMethod().getAddress());
+
+        e = (NMethodObject) information.getByAddress("0x00007fe0fbfe28d4");
+        assertEquals("NMethod", e.getType());
+        assertFalse(e.isHeapRoot());
+        assertEquals(11533, e.getSize());
+        assertEquals(4, e.getCompilationLevel());
+        assertEquals(3154, e.getId());
+        assertNotNull(e.getMethod());
+        assertEquals("(" + e.getCompilationLevel() + ") [" + e.getId()
+                + "] java.math.BigInteger.subtract([I[I)[I", e.getKey());
+        assertEquals("0x00000008003eecd8", e.getMethod().getAddress());
+
+        e = (NMethodObject) information.getByAddress("0x00007f9ab3fe6c60");
+        assertEquals("NMethod", e.getType());
+        assertFalse(e.isHeapRoot());
+        assertEquals(2444, e.getSize());
+        assertEquals(2, e.getCompilationLevel());
+        assertEquals(2550, e.getId());
+        assertNotNull(e.getMethod());
+        assertNull(e.getMethod().getAddress());
+        assertEquals("(" + e.getCompilationLevel() + ") [" + e.getId()
+                + "] java.util.Arrays.sort([Ljava/lang/Object;Ljava/util/Comparator;)V", e.getKey());
+        assertEquals("void java.util.Arrays.sort(java.lang.Object[], java.util.Comparator)", e.getMethod().getKey());
+    }
 }


### PR DESCRIPTION
Merge after https://github.com/vnkozlov/jdk/pull/1 (in case we change the final format).

Support for 8380476: Implement JEP: Ahead-of-Time Code Compilation

```
0x00007fbcf7ffeff4: @@ StubGenBlob       25896 73 initial_blob (stub gen)
0x00007fbcf7ffefc8: @@ SharedBlob        403 13 throw_StackOverflowError_blob (shared runtime)
0x00007fbcf7ffef9c: @@ StubGenBlob       3621 74 continuation_blob (stub gen)
0x00007fbcf7ffed34: @@ SharedBlob        2156 0 deopt_blob (shared runtime)
0x00007fbcf7ffe49c: @@ StubGenBlob       129373 75 compiler_blob (stub gen)
0x00007fbcf7ffe470: @@ StubGenBlob       59182 76 final_blob (stub gen)
0x00007fbcf7ffcc8c: @@ C1Blob            650 17 dtrace_object_alloc_blob (C1 runtime)
0x00007fbcf7ffcc60: @@ C1Blob            387 18 unwind_exception_blob (C1 runtime)
0x00007fbcf7ffbe74: @@ C2Blob            335 70 vthread_start_transition_blob (C2 runtime)
0x00007fbcf7ffbe48: @@ Adapter           1333 217 ILIL
0x00007fbcf7ffbe1c: @@ Adapter           1376 218 LIIILLL
0x00007fbcf7ffbdf0: @@ C2Blob            333 71 vthread_end_transition_blob (C2 runtime)
0x00007fbcf7ffbdc4: @@ Adapter           1460 219 LLLIILILLII
0x00007fbcf7ffbd98: @@ Adapter           1342 220 LIIIL
0x00007fbcf7fe5500: @@ Nmethod           2788 2 2906 java.util.concurrent.ConcurrentHashMap$MapEntry.<init>(Ljava/lang/Object;Ljava/lang/Object;Ljava/util/concurrent/ConcurrentHashMap;)V
0x00007fbcf7fe54d4: @@ Nmethod           5552 2 2905 java.util.concurrent.ConcurrentHashMap$EntryIterator.next()Ljava/util/Map$Entry;
0x00007fbcf7fe25e8: @@ Nmethod           11537 4 3183 java.math.BigInteger.subtract([I[I)[I
0x00007fbcf7fe25bc: @@ Nmethod           6965 4 3251 java.util.regex.Pattern$CharProperty.match(Ljava/util/regex/Matcher;ILjava/lang/CharSequence;)Z
```


## Type of change

Please delete options that are not relevant.
 
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
 It includes a unit test.

## Screenshots (if appropriate):

## Checklist:

- [x] This is not AI slop
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

