### PR TITLE
fix: Unpinned tag for a non-immutable Action in workflow

### DIFF
--- a/.github/workflows/check-pr-checks.yml
+++ b/.github/workflows/check-pr-checks.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: peternied/check-pull-request-description-checklist@v1.1
+      - uses: peternied/check-pull-request-description-checklist@ec79db61b595a5f3bea6df7963f818c013845b89
         with:
           checklist-items: |
                   This is not AI generated and I own the assets pushed


### PR DESCRIPTION


 Unpinned 3rd party Action 'PR mandatory checks' step Uses Step uses 'peternied/check-pull-request-description-checklist' with ref 'v1.1', not a pinned commit hash
CodeQL


## Screenshots (if appropriate):

## Checklist:

- [x] This is not AI generated and I own the assets pushed
- [x] I have added tests that prove my fix is effective or that my feature works

