### PR TITLE
feat: Allow for "trained" parameter to be null or false (filter by not trained)

### DIFF
--- a/src/main/java/tooling/leyden/aotcache/Information.java
+++ b/src/main/java/tooling/leyden/aotcache/Information.java
@@ -320,8 +320,12 @@ public class Information {
             });
         }
 
-        if (parameters.getTrained()) {
-            result = result.filter(e -> e.isTraineable() && e.isTrained());
+        if (parameters.getTrained() != null) {
+            if (parameters.getTrained()) {
+                result = result.filter(e -> e.isTraineable() && e.isTrained());
+            } else {
+                result = result.filter(e -> e.isTraineable() && !e.isTrained());
+            }
         }
 
         if (!parameters.getLambdas()) {

--- a/src/main/java/tooling/leyden/commands/CommonParameters.java
+++ b/src/main/java/tooling/leyden/commands/CommonParameters.java
@@ -64,9 +64,10 @@ public class CommonParameters {
             "Display object instances from this Java Class." }, arity = "0..1", completionCandidates = Identifiers.class)
     protected String instanceOf;
 
-    @CommandLine.Option(names = { "--trained" }, description = { "Only displays elements with training information.",
-            "This may restrict the types of elements shown, along with what was passed as parameters." }, defaultValue = "false", negatable = true, arity = "0..1")
-    protected Boolean trained = false;
+    @CommandLine.Option(names = { "--trained" },
+            description = { "Only displays elements with training information (true) or without training information (false).",
+            "This may restrict the types of elements shown, along with what was passed as parameters." }, negatable = true, arity = "0..1")
+    protected Boolean trained;
 
     @CommandLine.Option(names = { "--lambdas" }, description = {
             "Display lambda classes too. Useful to hide lambda classes." }, defaultValue = "true", negatable = true, arity = "0..1")

--- a/src/test/java/tooling/leyden/commands/ListCommandTest.java
+++ b/src/test/java/tooling/leyden/commands/ListCommandTest.java
@@ -65,22 +65,22 @@ class ListCommandTest extends DefaultTest {
         command.parameters.innerClasses = true;
         command.parameters.trained = false;
         command.parameters.loaded = WhichRun.all;
-        assertEquals(21, command.findElements(new AtomicInteger()).count());
+        assertEquals(4, command.findElements(new AtomicInteger()).count());
 
         var count = new AtomicInteger();
         command.parameters.types = new String[] { "Class" };
         assertTrue(command.findElements(count).allMatch(e -> e instanceof ClassObject));
-        assertEquals(2, count.get());
+        assertEquals(1, count.get());
 
         count = new AtomicInteger();
         command.parameters.types = new String[] { "Class", "Method" };
         assertTrue(command.findElements(count).allMatch(e -> e instanceof ClassObject || e instanceof MethodObject));
-        assertEquals(6, count.get());
+        assertEquals(4, count.get());
 
         command.parameters.types = new String[] { "Method" };
         count = new AtomicInteger();
         assertTrue(command.findElements(count).allMatch(Element::isTraineable));
-        assertEquals(4, count.get());
+        assertEquals(3, count.get());
 
         command.parameters.trained = true;
         count = new AtomicInteger();
@@ -89,7 +89,7 @@ class ListCommandTest extends DefaultTest {
 
 
         command.parameters.types = null;
-        command.parameters.trained = false;
+        command.parameters.trained = null;
         command.parameters.setNameLike("(.)*interceptors(.)*");
         count = new AtomicInteger();
         assertTrue(command.findElements(count).allMatch(e -> e.getKey().contains("interceptors")));


### PR DESCRIPTION
Previously, the parameter could only be true or false. And false meant no filtering.

Now we can filter by trained (true), not trained (false), or I don't care (null).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
It has unit tests.

## Checklist:

- [x] This is not AI generated and I own the assets pushed
- [x] I have added tests that prove my fix is effective or that my feature works

