### PR TITLE
fix: When a field was a primitive in aot map file, it threw an error

### DIFF
--- a/src/main/java/tooling/leyden/commands/logparser/AOTMapParser.java
+++ b/src/main/java/tooling/leyden/commands/logparser/AOTMapParser.java
@@ -193,9 +193,11 @@ public class AOTMapParser extends Parser {
             if (end != null) {
                 end = end.trim();
                 if (end.startsWith("java.lang.Class")) {
-                    end = end.substring(16, end.indexOf(";") + 1);
-                    var classObj = information.getElements(end.replaceAll("/", "."), null, null, true, true, "Symbol").findAny();
-                    classObj.ifPresent(element -> ((ReferencingElement) current).addReference(element));
+                    if (end.contains(";")) {
+                        end = end.substring(16, end.indexOf(";") + 1);
+                        var classObj = information.getElements(end.replaceAll("/", "."), null, null, true, true, "Symbol").findAny();
+                        classObj.ifPresent(element -> ((ReferencingElement) current).addReference(element));
+                    } // else it is a primitive
                 } else if (!end.equalsIgnoreCase("null") && !end.contains(" ")) {
                     //It may be that the instance class linked is a subclass of the one defined in m.group("classname")
                     var classObj = information.getElements(end, null, null, true, true, "Class").findAny();

--- a/src/test/java/tooling/leyden/commands/logparser/AOTCacheParserTest.java
+++ b/src/test/java/tooling/leyden/commands/logparser/AOTCacheParserTest.java
@@ -490,6 +490,7 @@ class AOTCacheParserTest extends DefaultTest {
                  - klass: 'java/lang/module/ModuleDescriptor$Version' 0x0000000800932e00
                  - fields (4 words):
                  - private final 'sequence' 'Ljava/util/List;' @16 0x00000000ffd07550 (0xffd07550) java.util.ArrayList
+                 - private final transient 'componentType' 'Ljava/lang/Class;' @72 0x000000026c946360 (0x3d928c6c) java.lang.Class I
                  - resolved_references: 0x00000000ffd07ba0 (0xffd07ba0) [Ljava.lang.Object; length: 18
                 0x00000000ffd07518:   00000001 00000000 00932e00 ffd07538 ffd07550 ffd07588 ffd075d0 00000000   ............8u..Pu...u...u......
 


### PR DESCRIPTION
Example:
`       - private final transient 'componentType' 'Ljava/lang/Class;' @72 0x000000026c946360 (0x3d928c6c) java.lang.Class I`

## How Has This Been Tested?
Unit test updated

## Checklist:

- [x] This is not AI generated and I own the assets pushed
- [x] I have added tests that prove my fix is effective or that my feature works

