### PR TITLE
fix: This HashSet should be synchronized

### DIFF
--- a/src/main/java/tooling/leyden/aotcache/Element.java
+++ b/src/main/java/tooling/leyden/aotcache/Element.java
@@ -1,11 +1,6 @@
 package tooling.leyden.aotcache;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStringBuilder;
@@ -21,7 +16,7 @@ public abstract class Element {
     private WhichRun loaded = WhichRun.None;
     private final List<String> whereDoesItComeFrom = new ArrayList<>();
     private final List<String> source = new ArrayList<>();
-    private final Set<Element> whoReferencesMe = new HashSet<>();
+    private final Set<Element> whoReferencesMe =  Collections.synchronizedSet(new HashSet<>());
     /**
      * Address where an element can be found
      */

--- a/src/main/java/tooling/leyden/aotcache/Information.java
+++ b/src/main/java/tooling/leyden/aotcache/Information.java
@@ -28,9 +28,9 @@ public class Information {
     private final Map<Key, Element> elementsNotInTheCache = new ConcurrentHashMap<>();
 
     //List of warnings and incidents that may be useful to check
-    private final List<Warning> warnings = new ArrayList<>();
+    private final List<Warning> warnings = Collections.synchronizedList(new ArrayList<>());
     //Auto-generated warnings by `warning check` command
-    private final List<Warning> autoWarnings = new ArrayList<>();
+    private final List<Warning> autoWarnings = Collections.synchronizedList(new ArrayList<>());
 
     //Store information extracted and inferred
     private final Configuration configuration = new Configuration();

--- a/src/main/java/tooling/leyden/aotcache/ReferencingElement.java
+++ b/src/main/java/tooling/leyden/aotcache/ReferencingElement.java
@@ -1,17 +1,13 @@
 package tooling.leyden.aotcache;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Elements that refer to other types of elements. For example: An element in the ConstantPool may be of certain
  * class, which is defined and loaded on the Information independently.
  **/
 public class ReferencingElement extends Element {
-    private final Set<Element> references = new HashSet<>();
+    private final Set<Element> references = Collections.synchronizedSet(new HashSet<>());
     private String name;
 
     public ReferencingElement(String name, String type) {


### PR DESCRIPTION
If we are loading more than one file at the same time in background, it could be there are concurrent calls to this field.

## How Has This Been Tested?
Manually, setting up a test for this would be a bit hard and overengineered.

## Checklist:

- [x] This is not AI generated and I own the assets pushed
- [x] I have added tests that prove my fix is effective or that my feature works

