### PR TITLE
fix: Simplified code to make it faster

### DIFF
--- a/src/main/java/tooling/leyden/aotcache/Information.java
+++ b/src/main/java/tooling/leyden/aotcache/Information.java
@@ -161,13 +161,17 @@ public class Information {
             var result = new ArrayList<Element>();
             for (String t : type) {
                 var k = new Key(key, t);
-                if (parameters.getUse() != CommonParameters.ElementsToUse.notCached
-                        && elements.containsKey(k)) {
-                    result.add(elements.get(k));
+                if (parameters.getUse() != CommonParameters.ElementsToUse.notCached) {
+                    var element = elements.get(k);
+                    if (element != null) {
+                        result.add(element);
+                    }
                 }
-                if (parameters.getUse() != CommonParameters.ElementsToUse.cached
-                        && elementsNotInTheCache.containsKey(k)) {
-                    result.add(elementsNotInTheCache.get(k));
+                if (parameters.getUse() != CommonParameters.ElementsToUse.cached) {
+                    var element = elementsNotInTheCache.get(k);
+                    if (element != null) {
+                        result.add(element);
+                    }
                 }
             }
             return result.parallelStream();


### PR DESCRIPTION
Also TOCTOU race when accessing elements fixed in the case of elements not in the cache. The elements in the cache never get removed.


## Checklist:

- [x] This is not AI generated and I own the assets pushed
- [x] I have added tests that prove my fix is effective or that my feature works

